### PR TITLE
Bug

### DIFF
--- a/src/main/java/org/pm/avro/test/AvroTest.java
+++ b/src/main/java/org/pm/avro/test/AvroTest.java
@@ -70,7 +70,7 @@ public class AvroTest {
             ioe.printStackTrace();
         }
         
-        printSummary(sizesSummary, sizesSummary, 
+        printSummary(timesSummary, sizesSummary, 
                         (System.currentTimeMillis() - startBenchmark));
     }
 


### PR DESCRIPTION
printSummary argument was taking the sizessummary twice. Fixed it.